### PR TITLE
Update CircularSlider.swift

### DIFF
--- a/HGCircularSlider/Classes/CircularSlider.swift
+++ b/HGCircularSlider/Classes/CircularSlider.swift
@@ -291,6 +291,10 @@ open class CircularSlider: UIControl {
     }
     
     // MARK: User interaction methods
+   
+    open override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false
+    }
     
     /**
      See superclass documentation


### PR DESCRIPTION
If UIViewController is in 'segue kind - present modally' mode (ios 13) the slider stops working because a gesture that closes the modal window (swipe down) is recognized